### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/eshell-fixed-prompt.el
+++ b/eshell-fixed-prompt.el
@@ -27,6 +27,11 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (defvar ivy-sort-functions-alist))
+
+(require 'em-prompt)
+(require 'em-hist)
 (require 's)
 
 (defun eshell-fixed-prompt-send-input ()


### PR DESCRIPTION
```
In eshell-fixed-prompt-send-input:
eshell-fixed-prompt.el:36:33:Warning: reference to free variable
    ‘eshell-prompt-function’

In eshell-fixed-prompt-remove-next-prompt:
eshell-fixed-prompt.el:73:40:Warning: reference to free variable
    ‘eshell-prompt-function’
eshell-fixed-prompt.el:92:1:Warning: Unused lexical variable
    ‘ivy-sort-functions-alist’

In eshell-fixed-prompt-select-history-item:
eshell-fixed-prompt.el:96:62:Warning: reference to free variable
    ‘eshell-history-ring’

In eshell-fixed-prompt-mode:
eshell-fixed-prompt.el:121:17:Warning: reference to free variable
    ‘eshell-output-filter-functions’
eshell-fixed-prompt.el:122:26:Warning: assignment to free variable
    ‘eshell-output-filter-functions’

In end of data:
eshell-fixed-prompt.el:128:1:Warning: the following functions are not known to be defined:
    eshell/clear-scrollback, eshell-send-input, eshell-bol,
    eshell-goto-input-start
```